### PR TITLE
[BYOB-153] 모임목록페이지 스크롤 위치 정보를 LocalStorage에 관리하는 로직 비활성화

### DIFF
--- a/src/app/meetings/page.tsx
+++ b/src/app/meetings/page.tsx
@@ -63,9 +63,9 @@ const SORT_OPTIONS = [
 export default function MeetingsPage() {
   // 스크롤 위치 유지
   const [scrollY] = useLocalStorage("meeting-list-scroll", 0);
-  useEffect(() => {
-    if (+scrollY !== 0) window.scrollTo(0, +scrollY);
-  }, [scrollY]);
+  // useEffect(() => {
+  //   if (+scrollY !== 0) window.scrollTo(0, +scrollY);
+  // }, [scrollY]);
 
   // 정렬 옵션 상태 관리
   const [sortOption, setSortOption] = useState("created-at");

--- a/src/app/meetings/page.tsx
+++ b/src/app/meetings/page.tsx
@@ -62,7 +62,7 @@ const SORT_OPTIONS = [
 
 export default function MeetingsPage() {
   // 스크롤 위치 유지
-  const [scrollY] = useLocalStorage("meeting-list-scroll", 0);
+  // const [scrollY] = useLocalStorage("meeting-list-scroll", 0);
   // useEffect(() => {
   //   if (+scrollY !== 0) window.scrollTo(0, +scrollY);
   // }, [scrollY]);

--- a/src/components/MeetingCard/MeetingCard.tsx
+++ b/src/components/MeetingCard/MeetingCard.tsx
@@ -24,7 +24,7 @@ import Image from "next/image";
 
 export default function MeetingCard({ meeting }: { meeting: MeetingInfo }) {
   const [visible, setVisible] = useState(false);
-  const [scrollY, setScrollY] = useLocalStorage("meeting-list-scroll", 0);
+  // const [scrollY, setScrollY] = useLocalStorage("meeting-list-scroll", 0);
 
   // IntersectionObserver API 설정: 뷰포트 안에 요소가 들어올 때만 DOM에 마운트
   const target = useRef(null);
@@ -44,7 +44,7 @@ export default function MeetingCard({ meeting }: { meeting: MeetingInfo }) {
   return (
     <LinkButton
       ref={target}
-      onClick={() => setScrollY(window.scrollY)}
+      // onClick={() => setScrollY(window.scrollY)}
       href={`/meetings/${meeting.id}`}
     >
       {visible && (


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-153]**

<br>

## 🔨 작업 사항 
- LocalStorage에 저장하는 스크롤 위치에 대한 유효 시간이 존재하지 않아서 사이트에 재방문할때도 스크롤 위치가 유지되는 문제 발생
- 우선은 관련 로직 비활성화: 현재 상태에서 크게 의미 있는 기능은 아님
- 추후 관련 로직 개선해서 다시 활성화시킬 예정

[BYOB-153]: https://swm-alcoholic.atlassian.net/browse/BYOB-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ