### PR TITLE
[BYOB-166] 주류 상세정보 페이지 구현: 유저 테이스팅 리뷰 미적용

### DIFF
--- a/new-types.d.ts
+++ b/new-types.d.ts
@@ -36,7 +36,7 @@ interface MeetingDetailInfo extends MeetingInfo {
 }
 
 interface LiquorInfo {
-  product_id: number;
+  id: number;
   en_name: string;
   ko_name: string;
   price: string;

--- a/new-types.d.ts
+++ b/new-types.d.ts
@@ -52,3 +52,38 @@ interface LiquorInfo {
   grape_variety: string;
   notes_count: number;
 }
+
+interface LiquorData {
+  thumbnailImageUrl: string | null;
+  koName: string | null;
+  enName: string | null;
+  type: string | null;
+  abv: string | null;
+  volume: string | null;
+  country: string | null;
+  tastingNotesAroma: string | null;
+  tastingNotesTaste: string | null;
+  tastingNotesFinish: string | null;
+  region: string | null;
+  grapeVariety: string | null;
+  aiNotes: aiNotes | null;
+}
+
+// Props Types
+
+interface LiquorTitleProps {
+  thumbnailImageUrl: string | null;
+  koName: string | null;
+  type: string | null;
+  abv: string | null;
+  volume: string | null;
+  country: string | null;
+  region: string | null;
+  grapeVariety: string | null;
+}
+
+interface KeyValueInfoProps {
+  keyContent: string | null;
+  valueContent: string | null;
+  keyMinWidth: number;
+}

--- a/src/api/tastingNotesApi.ts
+++ b/src/api/tastingNotesApi.ts
@@ -1,19 +1,3 @@
-export interface LiquorData {
-  thumbnailImageUrl: string | null;
-  koName: string | null;
-  enName: string | null;
-  type: string | null;
-  abv: string | null;
-  volume: string | null;
-  country: string | null;
-  tastingNotesAroma: string | null;
-  tastingNotesTaste: string | null;
-  tastingNotesFinish: string | null;
-  region: string | null;
-  grapeVariety: string | null;
-  aiNotes: aiNotes | null;
-}
-
 export interface aiNotes {
   tastingNotesAroma: string;
   tastingNotesTaste: string;

--- a/src/api/tastingNotesApi.ts
+++ b/src/api/tastingNotesApi.ts
@@ -1,6 +1,7 @@
 export interface LiquorData {
   thumbnailImageUrl: string | null;
-  koName: string;
+  koName: string | null;
+  enName: string | null;
   type: string | null;
   abv: string | null;
   volume: string | null;
@@ -54,10 +55,10 @@ export const fetchAiNotes = async (): Promise<aiNotes> => {
 
 export const fetchRelatedNotes = async (
   note: string,
-  exclude: string,
+  exclude: string
 ): Promise<string[]> => {
   const response = await fetch(
-    `${LIQUOR_NOTES_URL}?keyword=${encodeURIComponent(note)}&exclude=${encodeURIComponent(exclude)}&limit=5`,
+    `${LIQUOR_NOTES_URL}?keyword=${encodeURIComponent(note)}&exclude=${encodeURIComponent(exclude)}&limit=5`
   );
   if (!response.ok) throw new Error("Failed to fetch related notes");
   return await response.json();

--- a/src/app/liquors/[id]/page.tsx
+++ b/src/app/liquors/[id]/page.tsx
@@ -14,7 +14,6 @@ const getLiquorInfo = async (id: string) => {
     throw new Error("Failed to fetch data");
   }
   const data: LiquorData = await res.json();
-  console.log(data);
   return data;
 };
 
@@ -45,7 +44,7 @@ export default async function LiquorDetailPage({
       </Box>
 
       {/* 주류 정보 */}
-      <Stack sx={{ gap: "40px" }}>
+      <Stack sx={{ gap: "50px" }}>
         {/* 이름 */}
         <Stack>
           <Typography sx={{ color: "gray", fontSize: "10px" }}>
@@ -61,57 +60,67 @@ export default async function LiquorDetailPage({
         </Stack>
 
         {/* 정보 */}
-        <Stack sx={{ gap: "8px" }}>
-          <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
-            주류 정보
-          </Typography>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "35px", color: "gray" }}>
-              분류
+        <Stack
+          sx={{
+            border: "solid 1px #cccccc",
+            borderRadius: "5px 5px",
+            padding: "30px",
+            gap: "50px",
+          }}
+        >
+          {/* 기본 정보 */}
+          <Stack sx={{ gap: "8px" }}>
+            <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+              주류 기본 정보
             </Typography>
-            <Typography>{liquor.type}</Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "35px", color: "gray" }}>
-              도수
-            </Typography>
-            <Typography>{liquor.abv}</Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "35px", color: "gray" }}>
-              국가
-            </Typography>
-            <Typography>{liquor.country}</Typography>
-          </Box>
-        </Stack>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "35px", color: "gray" }}>
+                분류
+              </Typography>
+              <Typography>{liquor.type}</Typography>
+            </Box>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "35px", color: "gray" }}>
+                도수
+              </Typography>
+              <Typography>{liquor.abv}</Typography>
+            </Box>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "35px", color: "gray" }}>
+                국가
+              </Typography>
+              <Typography>{liquor.country}</Typography>
+            </Box>
+          </Stack>
 
-        {/* 테이스팅 노트 */}
-        <Stack sx={{ gap: "8px" }}>
-          <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
-            테이스팅 정보
-          </Typography>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "100px", color: "gray" }}>
-              향 (Aroma)
+          {/* 테이스팅 노트 */}
+          <Stack sx={{ gap: "8px" }}>
+            <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+              테이스팅 정보
             </Typography>
-            <Typography>{liquor.tastingNotesAroma}</Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "100px", color: "gray" }}>
-              맛 (Taste)
-            </Typography>
-            <Typography>{liquor.tastingNotesTaste}</Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-            <Typography sx={{ minWidth: "100px", color: "gray" }}>
-              여운 (Finish)
-            </Typography>
-            <Typography>{liquor.tastingNotesFinish}</Typography>
-          </Box>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "100px", color: "gray" }}>
+                향 (Aroma)
+              </Typography>
+              <Typography>{liquor.tastingNotesAroma}</Typography>
+            </Box>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "100px", color: "gray" }}>
+                맛 (Taste)
+              </Typography>
+              <Typography>{liquor.tastingNotesTaste}</Typography>
+            </Box>
+            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+              <Typography sx={{ minWidth: "100px", color: "gray" }}>
+                여운 (Finish)
+              </Typography>
+              <Typography>{liquor.tastingNotesFinish}</Typography>
+            </Box>
+          </Stack>
         </Stack>
       </Stack>
 
-      {/* 주류 리뷰 */}
+      {/* 주류 리뷰: 컴포넌트 구현 필요 */}
       <Stack sx={{ marginTop: "50px" }}>
         <Typography sx={{ fontSize: "22px", fontWeight: "600" }}>
           커뮤니티 리뷰

--- a/src/app/liquors/[id]/page.tsx
+++ b/src/app/liquors/[id]/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 const getLiquorInfo = async (id: string) => {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/liquorsearch/${id}`
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/liquors/${id}`
   );
 
   if (!res.ok) {
@@ -13,7 +13,7 @@ const getLiquorInfo = async (id: string) => {
     }
     throw new Error("Failed to fetch data");
   }
-  const data: LiquorInfo = await res.json();
+  const data: LiquorData = await res.json();
   console.log(data);
   return data;
 };
@@ -37,7 +37,7 @@ export default async function LiquorDetailPage({
         }}
       >
         <Image
-          src={liquor.thumbnail_image_url}
+          src={liquor.thumbnailImageUrl ? liquor.thumbnailImageUrl : "default"}
           alt="주류 이미지"
           width={255}
           height={255}
@@ -52,10 +52,10 @@ export default async function LiquorDetailPage({
             데일리샷 정보
           </Typography>
           <Typography sx={{ fontSize: "25px", fontWeight: "700" }}>
-            {liquor.ko_name}
+            {liquor.koName}
           </Typography>
           <Typography sx={{ color: "gray", fontSize: "15px" }}>
-            {liquor.en_name}
+            {liquor.enName}
           </Typography>
           <Divider sx={{ margin: "10px 0" }} />
         </Stack>
@@ -94,19 +94,19 @@ export default async function LiquorDetailPage({
             <Typography sx={{ minWidth: "100px", color: "gray" }}>
               향 (Aroma)
             </Typography>
-            <Typography>{liquor.tasting_notes_Aroma}</Typography>
+            <Typography>{liquor.tastingNotesAroma}</Typography>
           </Box>
           <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
             <Typography sx={{ minWidth: "100px", color: "gray" }}>
               맛 (Taste)
             </Typography>
-            <Typography>{liquor.tasting_notes_Taste}</Typography>
+            <Typography>{liquor.tastingNotesTaste}</Typography>
           </Box>
           <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
             <Typography sx={{ minWidth: "100px", color: "gray" }}>
               여운 (Finish)
             </Typography>
-            <Typography>{liquor.tasting_notes_Finish}</Typography>
+            <Typography>{liquor.tastingNotesFinish}</Typography>
           </Box>
         </Stack>
       </Stack>

--- a/src/app/liquors/[id]/page.tsx
+++ b/src/app/liquors/[id]/page.tsx
@@ -1,3 +1,115 @@
-export default function LiquorDetailPage() {
-  return <h1>Liquor Detail Page</h1>;
+import { LiquorData } from "@/api/tastingNotesApi";
+import { Box, Divider, Stack, styled, Typography } from "@mui/material";
+import Image from "next/image";
+
+const getLiquorInfo = async (id: string) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/liquorsearch/${id}`
+  );
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("404");
+    }
+    throw new Error("Failed to fetch data");
+  }
+  const data: LiquorInfo = await res.json();
+  console.log(data);
+  return data;
+};
+
+export default async function LiquorDetailPage({
+  params: { id },
+}: {
+  params: { id: string };
+}) {
+  // 주류 데이터
+  const liquor = await getLiquorInfo(id);
+
+  return (
+    <Stack sx={{ marginTop: "30px" }}>
+      {/* 주류 이미지 */}
+      <Box
+        sx={{
+          width: "100%",
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <Image
+          src={liquor.thumbnail_image_url}
+          alt="주류 이미지"
+          width={255}
+          height={255}
+        />
+      </Box>
+
+      {/* 주류 정보 */}
+      <Stack sx={{ margin: "30px 0", padding: "0 30px", gap: "40px" }}>
+        {/* 이름 */}
+        <Stack>
+          <Typography sx={{ color: "gray", fontSize: "10px" }}>
+            데일리샷 정보
+          </Typography>
+          <Typography sx={{ fontSize: "20px" }}>{liquor.ko_name}</Typography>
+          <Typography sx={{ color: "gray", fontSize: "15px" }}>
+            {liquor.en_name}
+          </Typography>
+          <Divider sx={{ margin: "10px 0" }} />
+        </Stack>
+
+        {/* 정보 */}
+        <Stack sx={{ gap: "8px" }}>
+          <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+            주류 정보
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "35px", color: "gray" }}>
+              분류
+            </Typography>
+            <Typography>{liquor.type}</Typography>
+          </Box>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "35px", color: "gray" }}>
+              도수
+            </Typography>
+            <Typography>{liquor.abv}</Typography>
+          </Box>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "35px", color: "gray" }}>
+              국가
+            </Typography>
+            <Typography>{liquor.country}</Typography>
+          </Box>
+        </Stack>
+
+        {/* 테이스팅 노트 */}
+        <Stack sx={{ gap: "8px" }}>
+          <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+            테이스팅 정보
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "100px", color: "gray" }}>
+              향 (Aroma)
+            </Typography>
+            <Typography>{liquor.tasting_notes_Aroma}</Typography>
+          </Box>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "100px", color: "gray" }}>
+              맛 (Taste)
+            </Typography>
+            <Typography>{liquor.tasting_notes_Taste}</Typography>
+          </Box>
+          <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+            <Typography sx={{ minWidth: "100px", color: "gray" }}>
+              여운 (Finish)
+            </Typography>
+            <Typography>{liquor.tasting_notes_Finish}</Typography>
+          </Box>
+        </Stack>
+
+        {/* 리뷰 */}
+      </Stack>
+    </Stack>
+  );
 }

--- a/src/app/liquors/[id]/page.tsx
+++ b/src/app/liquors/[id]/page.tsx
@@ -27,7 +27,7 @@ export default async function LiquorDetailPage({
   const liquor = await getLiquorInfo(id);
 
   return (
-    <Stack sx={{ marginTop: "30px" }}>
+    <Stack sx={{ marginTop: "30px", padding: "0 30px", gap: "30px" }}>
       {/* 주류 이미지 */}
       <Box
         sx={{
@@ -45,13 +45,15 @@ export default async function LiquorDetailPage({
       </Box>
 
       {/* 주류 정보 */}
-      <Stack sx={{ margin: "30px 0", padding: "0 30px", gap: "40px" }}>
+      <Stack sx={{ gap: "40px" }}>
         {/* 이름 */}
         <Stack>
           <Typography sx={{ color: "gray", fontSize: "10px" }}>
             데일리샷 정보
           </Typography>
-          <Typography sx={{ fontSize: "20px" }}>{liquor.ko_name}</Typography>
+          <Typography sx={{ fontSize: "25px", fontWeight: "700" }}>
+            {liquor.ko_name}
+          </Typography>
           <Typography sx={{ color: "gray", fontSize: "15px" }}>
             {liquor.en_name}
           </Typography>
@@ -107,8 +109,14 @@ export default async function LiquorDetailPage({
             <Typography>{liquor.tasting_notes_Finish}</Typography>
           </Box>
         </Stack>
+      </Stack>
 
-        {/* 리뷰 */}
+      {/* 주류 리뷰 */}
+      <Stack sx={{ marginTop: "50px" }}>
+        <Typography sx={{ fontSize: "22px", fontWeight: "600" }}>
+          커뮤니티 리뷰
+        </Typography>
+        <Divider sx={{ margin: "5px 0" }} />
       </Stack>
     </Stack>
   );

--- a/src/app/liquors/[id]/page.tsx
+++ b/src/app/liquors/[id]/page.tsx
@@ -1,12 +1,12 @@
-import { LiquorData } from "@/api/tastingNotesApi";
+import LiquorInfoCardComponent from "@/components/LiquorInfoCardComponent/LiquorInfoCardComponent";
 import { Box, Divider, Stack, styled, Typography } from "@mui/material";
 import Image from "next/image";
 
+/** 주류 상세정보 API 요청 함수 */
 const getLiquorInfo = async (id: string) => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/liquors/${id}`
   );
-
   if (!res.ok) {
     if (res.status === 404) {
       throw new Error("404");
@@ -16,6 +16,8 @@ const getLiquorInfo = async (id: string) => {
   const data: LiquorData = await res.json();
   return data;
 };
+
+/** 주류 정보 */
 
 export default async function LiquorDetailPage({
   params: { id },
@@ -60,64 +62,7 @@ export default async function LiquorDetailPage({
         </Stack>
 
         {/* 정보 */}
-        <Stack
-          sx={{
-            border: "solid 1px #cccccc",
-            borderRadius: "5px 5px",
-            padding: "30px",
-            gap: "50px",
-          }}
-        >
-          {/* 기본 정보 */}
-          <Stack sx={{ gap: "8px" }}>
-            <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
-              주류 기본 정보
-            </Typography>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "35px", color: "gray" }}>
-                분류
-              </Typography>
-              <Typography>{liquor.type}</Typography>
-            </Box>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "35px", color: "gray" }}>
-                도수
-              </Typography>
-              <Typography>{liquor.abv}</Typography>
-            </Box>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "35px", color: "gray" }}>
-                국가
-              </Typography>
-              <Typography>{liquor.country}</Typography>
-            </Box>
-          </Stack>
-
-          {/* 테이스팅 노트 */}
-          <Stack sx={{ gap: "8px" }}>
-            <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
-              테이스팅 정보
-            </Typography>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "100px", color: "gray" }}>
-                향 (Aroma)
-              </Typography>
-              <Typography>{liquor.tastingNotesAroma}</Typography>
-            </Box>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "100px", color: "gray" }}>
-                맛 (Taste)
-              </Typography>
-              <Typography>{liquor.tastingNotesTaste}</Typography>
-            </Box>
-            <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
-              <Typography sx={{ minWidth: "100px", color: "gray" }}>
-                여운 (Finish)
-              </Typography>
-              <Typography>{liquor.tastingNotesFinish}</Typography>
-            </Box>
-          </Stack>
-        </Stack>
+        <LiquorInfoCardComponent liquor={liquor} />
       </Stack>
 
       {/* 주류 리뷰: 컴포넌트 구현 필요 */}

--- a/src/app/liquors/page.tsx
+++ b/src/app/liquors/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import LiquorTitle from "@/components/TastingNotesComponent/LiquorTitle";
-import { AccountCircle, Search } from "@mui/icons-material";
+import { Search } from "@mui/icons-material";
 import {
   Box,
   InputAdornment,

--- a/src/app/liquors/page.tsx
+++ b/src/app/liquors/page.tsx
@@ -58,10 +58,7 @@ export default function LiquorsPage() {
       {status == "success" &&
         (data && data.length ? (
           data.map((liquor: LiquorInfo) => (
-            <LiquorCardLink
-              key={liquor.product_id}
-              href={`/liquors/${liquor.product_id}`}
-            >
+            <LiquorCardLink key={liquor.id} href={`/liquors/${liquor.id}`}>
               <LiquorTitle
                 thumbnailImageUrl={liquor.thumbnail_image_url}
                 koName={liquor.ko_name}

--- a/src/app/tasting-notes/new/page.tsx
+++ b/src/app/tasting-notes/new/page.tsx
@@ -15,7 +15,6 @@ import {
   fetchAiNotes,
   fetchLiquorData,
   fetchRelatedNotes,
-  LiquorData,
   ReviewSavingData,
   saveReviewData,
 } from "@/api/tastingNotesApi";
@@ -50,26 +49,26 @@ const TastingNotesNewPage = () => {
         const data = await fetchLiquorData();
         setLiquorData(data);
         let tastingNotesAroma = new Set(
-          data.tastingNotesAroma?.split(", ") || [],
+          data.tastingNotesAroma?.split(", ") || []
         );
         let tastingNotesTaste = new Set(
-          data.tastingNotesTaste?.split(", ") || [],
+          data.tastingNotesTaste?.split(", ") || []
         );
         let tastingNotesFinish = new Set(
-          data.tastingNotesFinish?.split(", ") || [],
+          data.tastingNotesFinish?.split(", ") || []
         );
 
         if (data.aiNotes) {
           setHasAiNotes(true);
           data.aiNotes.tastingNotesAroma
             .split(", ")
-            .forEach((note) => tastingNotesAroma.add(note));
+            .forEach((note: string) => tastingNotesAroma.add(note));
           data.aiNotes.tastingNotesTaste
             .split(", ")
-            .forEach((note) => tastingNotesTaste.add(note));
+            .forEach((note: string) => tastingNotesTaste.add(note));
           data.aiNotes.tastingNotesFinish
             .split(", ")
-            .forEach((note) => tastingNotesFinish.add(note));
+            .forEach((note: string) => tastingNotesFinish.add(note));
         } else setHasAiNotes(false);
 
         setRelatedNotes([
@@ -124,7 +123,7 @@ const TastingNotesNewPage = () => {
   };
   const updateSetRelatedNotes = (
     newRelatedNotes: string[],
-    currentTab: number,
+    currentTab: number
   ) => {
     setRelatedNotes((prev) => {
       const updatedRelatedNotes = [...prev];

--- a/src/components/LiquorInfoCardComponent/KeyValueInfoComponent.tsx
+++ b/src/components/LiquorInfoCardComponent/KeyValueInfoComponent.tsx
@@ -1,0 +1,16 @@
+import { Box, Typography } from "@mui/material";
+
+export default function KeyValueInfoComponent({
+  keyContent,
+  valueContent,
+  keyMinWidth,
+}: KeyValueInfoProps) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+      <Typography sx={{ minWidth: `${keyMinWidth}px`, color: "gray" }}>
+        {keyContent}
+      </Typography>
+      <Typography>{valueContent}</Typography>
+    </Box>
+  );
+}

--- a/src/components/LiquorInfoCardComponent/LiquorInfoCardComponent.tsx
+++ b/src/components/LiquorInfoCardComponent/LiquorInfoCardComponent.tsx
@@ -1,0 +1,62 @@
+import { Box, Divider, Stack, Typography } from "@mui/material";
+import KeyValueInfoComponent from "./KeyValueInfoComponent";
+
+export default function LiquorInfoCardComponent({
+  liquor,
+}: {
+  liquor: LiquorData;
+}) {
+  /** 주류 기본 정보 */
+  const LIQUOR_INFO_FIELDS = [
+    { keyContent: "분류", valueContent: liquor.type },
+    { keyContent: "도수", valueContent: liquor.abv },
+    { keyContent: "국가", valueContent: liquor.country },
+  ];
+  /** 주류 테이스팅 정보 */
+  const LIQUOR_TASTING_FIELDS = [
+    { keyContent: "향 (Aroma)", valueContent: liquor.tastingNotesAroma },
+    { keyContent: "맛 (Taste)", valueContent: liquor.tastingNotesTaste },
+    { keyContent: "여운 (Finish)", valueContent: liquor.tastingNotesFinish },
+  ];
+
+  return (
+    <Stack
+      sx={{
+        border: "solid 1px #cccccc",
+        borderRadius: "5px 5px",
+        padding: "30px",
+        gap: "50px",
+      }}
+    >
+      {/* 기본 정보 */}
+      <Stack sx={{ gap: "8px" }}>
+        <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+          주류 기본 정보
+        </Typography>
+        {LIQUOR_INFO_FIELDS.map((data) => (
+          <KeyValueInfoComponent
+            key={data.keyContent}
+            keyContent={data.keyContent}
+            valueContent={data.valueContent}
+            keyMinWidth={35}
+          />
+        ))}
+      </Stack>
+
+      {/* 테이스팅 노트 */}
+      <Stack sx={{ gap: "8px" }}>
+        <Typography sx={{ fontSize: "18px", fontWeight: "600" }}>
+          테이스팅 정보
+        </Typography>
+        {LIQUOR_TASTING_FIELDS.map((data) => (
+          <KeyValueInfoComponent
+            key={data.keyContent}
+            keyContent={data.keyContent}
+            valueContent={data.valueContent}
+            keyMinWidth={100}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/TastingNotesComponent/LiquorTitle.tsx
+++ b/src/components/TastingNotesComponent/LiquorTitle.tsx
@@ -5,17 +5,6 @@ import {
   WhiskeyImage,
 } from "@/app/tasting-notes/new/StyledComponent";
 
-interface LiquorTitleProps {
-  thumbnailImageUrl: string | null;
-  koName: string;
-  type: string | null;
-  abv: string | null;
-  volume: string | null;
-  country: string | null;
-  region: string | null;
-  grapeVariety: string | null;
-}
-
 const LiquorTitle: React.FC<LiquorTitleProps> = ({
   thumbnailImageUrl,
   koName,


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-166]**

<br>

## 🔨 작업 사항 
**작업 사항 1: 주류 상세정보 페이지 구현**
주류 검색 페이지에서 주류 선택 시 이동할 주류 상세정보 페이지를 구현함
이후 주류 상세정보 페이지에서 유저 테이스팅 리뷰까지 볼 수 있도록 개선할 예정
<img width="549" alt="스크린샷 2024-08-12 오전 1 05 55" src="https://github.com/user-attachments/assets/ee0c1566-2e08-48c6-ae0f-e06ef6fe0335">

**작업 사항 2: 타입 관련 리팩토링**
동석이가 만들어뒀던 타입(`LiquorData`, `LiquorTitleProps`) 재사용이 필요해서 `new-types.d.ts` 파일로 옮겨둠



[BYOB-166]: https://swm-alcoholic.atlassian.net/browse/BYOB-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ