### PR TITLE
[BYOB-227] 무카와 일본어 검색 기능 보완

### DIFF
--- a/src/constants/whiskyDictionary.ts
+++ b/src/constants/whiskyDictionary.ts
@@ -254,4 +254,561 @@ export const whiskyDictionary = {
     ja: "ローグ スピリッツ",
   },
   wildturkey: { en: "Wild Turkey", ko: "와일드 터키", ja: "ワイルドターキー" },
+  glencadam: { en: "Glencadam", ko: "글렌캐덤", ja: "グレンカダム" },
+  edradour: { en: "Edradour", ko: "에드라두어", ja: "エドラダワー" },
+  tobermory: { en: "Tobermory", ko: "토버모리", ja: "トバモリー" },
+  ledaig: { en: "Ledaig", ko: "레데익", ja: "レダイグ" },
+  benromach: { en: "Benromach", ko: "벤로막", ja: "ベンロマック" },
+  deanston: { en: "Deanston", ko: "딘스톤", ja: "ディーンストン" },
+  royalbrackla: {
+    en: "Royal Brackla",
+    ko: "로얄 브랙클라",
+    ja: "ロイヤルブラッカラ",
+  },
+  strathisla: { en: "Strathisla", ko: "스트래시라", ja: "ストラスアイラ" },
+  tamdhu: { en: "Tamdhu", ko: "탐듀", ja: "タムデュー" },
+  inchmurrin: { en: "Inchmurrin", ko: "인치머린", ja: "インチマリン" },
+  tomintoul: { en: "Tomintoul", ko: "토민톨", ja: "トミントール" },
+  mortlach: { en: "Mortlach", ko: "모트락", ja: "モートラック" },
+  glentauchers: {
+    en: "Glentauchers",
+    ko: "글렌토커스",
+    ja: "グレントッカーズ",
+  },
+  benriach: { en: "BenRiach", ko: "벤리악", ja: "ベンリアック" },
+  cardhu: { en: "Cardhu", ko: "카듀", ja: "カードゥ" },
+  auchroisk: { en: "Auchroisk", ko: "어크로이스크", ja: "オスロス" },
+  altmore: { en: "Aultmore", ko: "올트모어", ja: "オルトモア" },
+  glenkinchie: { en: "Glenkinchie", ko: "글렌킨치", ja: "グレンキンチー" },
+  speyburn: { en: "Speyburn", ko: "스페이버른", ja: "スペイバーン" },
+  knockando: { en: "Knockando", ko: "녹켄도", ja: "ノッカンドー" },
+  teaninich: { en: "Teaninich", ko: "티니니크", ja: "ティーニニック" },
+  glenlossie: { en: "Glenlossie", ko: "글렌로시", ja: "グレンロッシー" },
+  inchgower: { en: "Inchgower", ko: "인치가워", ja: "インチガワー" },
+  millburn: { en: "Millburn", ko: "밀번", ja: "ミルバーン" },
+  blairathol: { en: "Blair Athol", ko: "블레어 애솔", ja: "ブレアアソル" },
+  glenglassaugh: {
+    en: "Glenglassaugh",
+    ko: "글렌글라소",
+    ja: "グレンガッサウ",
+  },
+  tormore: { en: "Tormore", ko: "토모어", ja: "トーモア" },
+  dailuaine: { en: "Dailuaine", ko: "데일유안", ja: "ダルユエイン" },
+  benrinnes: { en: "Benrinnes", ko: "벤리네스", ja: "ベンリネス" },
+  glengoyne: { en: "Glengoyne", ko: "글렌고인", ja: "グレングーニ" },
+  tomatin: { en: "Tomatin", ko: "토마틴", ja: "トマーチン" },
+  yamazaki: { en: "Yamazaki", ko: "야마자키", ja: "山崎" },
+  hakushu: { en: "Hakushu", ko: "하쿠슈", ja: "白州" },
+  hibiki: { en: "Hibiki", ko: "히비키", ja: "響" },
+  toki: { en: "Toki", ko: "토키", ja: "時" },
+  nikka: { en: "Nikka", ko: "니카", ja: "ニッカ" },
+  yoichi: { en: "Yoichi", ko: "요이치", ja: "余市" },
+  miyagikyo: { en: "Miyagikyo", ko: "미야기쿄", ja: "宮城峡" },
+  togouchi: { en: "Togouchi", ko: "토고치", ja: "戸河内" },
+  mars: { en: "Mars", ko: "마르스", ja: "マース" },
+  chichibu: { en: "Chichibu", ko: "치치부", ja: "秩父" },
+
+  // Highland
+  fettercairn: { en: "Fettercairn", ko: "페터케른", ja: "フェッターケアン" },
+  glendronach: { en: "Glendronach", ko: "글렌드로낙", ja: "グレンドロナック" },
+  glenturret: { en: "Glenturret", ko: "글렌터렛", ja: "グレンターレット" },
+  oldpulteney: {
+    en: "Old Pulteney",
+    ko: "올드 펄트니",
+    ja: "オールドプルトニー",
+  },
+  tullibardine: { en: "Tullibardine", ko: "툴리바딘", ja: "タリバーディン" },
+
+  // Speyside
+  auchentoshen: {
+    en: "Auchentoshan",
+    ko: "오큰토션",
+    ja: "オーヘントッシャン",
+  },
+  bennevis: { en: "Ben Nevis", ko: "벤 네비스", ja: "ベンネヴィス" },
+  craigellachie: {
+    en: "Craigellachie",
+    ko: "크레이겔라키",
+    ja: "クレイガラキ",
+  },
+  glendullan: { en: "Glendullan", ko: "글렌덜란", ja: "グレンダラン" },
+  glengrant: { en: "Glen Grant", ko: "글렌그란트", ja: "グレングラント" },
+
+  // Islay
+  kilchoman: { en: "Kilchoman", ko: "킬호만", ja: "キルホーマン" },
+  portcharlotte: {
+    en: "Port Charlotte",
+    ko: "포트 샬롯",
+    ja: "ポートシャーロット",
+  },
+  portellen: { en: "Port Ellen", ko: "포트 엘렌", ja: "ポートエレン" },
+  octomore: { en: "Octomore", ko: "옥토모어", ja: "オクトモア" },
+
+  // Campbeltown
+  glengyle: { en: "Glengyle", ko: "글렌가일", ja: "グレンガイル" },
+  hazelburn: { en: "Hazelburn", ko: "헤이즐번", ja: "ヘーゼルバーン" },
+  longrow: { en: "Longrow", ko: "롱로우", ja: "ロングロウ" },
+
+  // Irish Whiskey
+  bushmills: { en: "Bushmills", ko: "부시밀스", ja: "ブッシュミルズ" },
+  greenspot: { en: "Green Spot", ko: "그린 스팟", ja: "グリーンスポット" },
+  jameson: { en: "Jameson", ko: "제임슨", ja: "ジェムソン" },
+  midleton: { en: "Midleton", ko: "미들턴", ja: "ミドルトン" },
+  powersjohn: {
+    en: "Powers John's Lane",
+    ko: "파워스 존스 레인",
+    ja: "パワーズジョンズレーン",
+  },
+  redbreast: { en: "Redbreast", ko: "레드브레스트", ja: "レッドブレスト" },
+  tullamore: {
+    en: "Tullamore D.E.W.",
+    ko: "툴라모어 듀",
+    ja: "タラモアデュー",
+  },
+  teeling: { en: "Teeling", ko: "틸링", ja: "ティーリング" },
+
+  // Canadian Whisky
+  crownroyal: { en: "Crown Royal", ko: "크라운 로얄", ja: "クラウンローヤル" },
+  canadianclub: {
+    en: "Canadian Club",
+    ko: "캐네디언 클럽",
+    ja: "カナディアンクラブ",
+  },
+  whistler: { en: "Whistler", ko: "휘슬러", ja: "ウィスラー" },
+  pikecreek: { en: "Pike Creek", ko: "파이크 크릭", ja: "パイククリーク" },
+
+  // World Whisky
+  kavalan: { en: "Kavalan", ko: "카발란", ja: "カバラン" },
+  amrut: { en: "Amrut", ko: "암룻", ja: "アムルット" },
+  pauljohn: { en: "Paul John", ko: "폴 존", ja: "ポールジョン" },
+  starward: { en: "Starward", ko: "스타워드", ja: "スターワード" },
+
+  // Lowland
+  auchentoshan: {
+    en: "Auchentoshan",
+    ko: "오큰토션",
+    ja: "オーヘントッシャン",
+  },
+  bladnoch: { en: "Bladnoch", ko: "블라드녹", ja: "ブラッドノック" },
+  rosebank: { en: "Rosebank", ko: "로즈뱅크", ja: "ローズバンク" },
+
+  // Additional Japanese
+  fuji: { en: "Fuji", ko: "후지", ja: "富士" },
+  akkeshi: { en: "Akkeshi", ko: "아케시", ja: "厚岸" },
+  kanosuke: { en: "Kanosuke", ko: "카노스케", ja: "鹿児島" },
+  ontake: { en: "Ontake", ko: "온타케", ja: "御岳" },
+  matsui: { en: "Matsui", ko: "마츠이", ja: "松井" },
+
+  // Additional Scotch
+  arran: { en: "Arran", ko: "아란", ja: "アラン" },
+  ballechin: { en: "Ballechin", ko: "발레친", ja: "バレッヒン" },
+  benrines: { en: "Ben Rines", ko: "벤 라인스", ja: "ベンライネス" },
+  glencahill: { en: "Glen Cahill", ko: "글렌 카힐", ja: "グレンカヒル" },
+
+  // Additional Irish
+  connemara: { en: "Connemara", ko: "코네마라", ja: "コネマラ" },
+  dunphys: { en: "Dunphy's", ko: "던피스", ja: "ダンフィーズ" },
+  egans: { en: "Egan's", ko: "이건스", ja: "イーガンズ" },
+
+  // Additional Bourbon
+  barterhouse: { en: "Barterhouse", ko: "바터하우스", ja: "バーターハウス" },
+  bloodath: { en: "Blood Oath", ko: "블러드 오스", ja: "ブラッドオース" },
+  buckhorn: { en: "Buckhorn", ko: "벅혼", ja: "バックホーン" },
+
+  // More Speyside
+  linkwood: { en: "Linkwood", ko: "링크우드", ja: "リンクウッド" },
+  mannochmore: { en: "Mannochmore", ko: "매녹모어", ja: "マノックモア" },
+  miltonduff: { en: "Miltonduff", ko: "밀턴더프", ja: "ミルトンダフ" },
+
+  // More Highland
+  glenallachie: { en: "GlenAllachie", ko: "글렌알라키", ja: "グレンアラヒー" },
+  glendeveron: { en: "Glen Deveron", ko: "글렌 데버론", ja: "グレンデベロン" },
+  glenforest: {
+    en: "Glen Forest",
+    ko: "글렌 포레스트",
+    ja: "グレンフォレスト",
+  },
+
+  // Additional World Whisky
+  mackmyra: { en: "Mackmyra", ko: "맥크미라", ja: "マックミーラ" },
+  millstone: { en: "Millstone", ko: "밀스톤", ja: "ミルストーン" },
+  penderyn: { en: "Penderyn", ko: "펜더린", ja: "ペンデリン" },
+
+  // More Japanese
+  eigashima: { en: "Eigashima", ko: "에이가시마", ja: "江井ヶ島" },
+  kurayoshi: { en: "Kurayoshi", ko: "쿠라요시", ja: "倉吉" },
+  okayama: { en: "Okayama", ko: "오카야마", ja: "岡山" },
+
+  // Additional Irish
+  knappogue: {
+    en: "Knappogue Castle",
+    ko: "나포그 캐슬",
+    ja: "ナポーグキャッスル",
+  },
+  slane: { en: "Slane", ko: "슬레인", ja: "スレーン" },
+  spotworth: { en: "Spot Worth", ko: "스팟 워스", ja: "スポットワース" },
+
+  // More Bourbon
+  cooperscraft: {
+    en: "Cooper's Craft",
+    ko: "쿠퍼스 크래프트",
+    ja: "クーパーズクラフト",
+  },
+  davidnicholson: {
+    en: "David Nicholson",
+    ko: "데이비드 니콜슨",
+    ja: "デービッドニコルソン",
+  },
+  earlybird: { en: "Early Bird", ko: "얼리 버드", ja: "アーリーバード" },
+  johnniewalker: {
+    en: "Johnnie Walker",
+    ko: "조니 워커",
+    ja: "ジョニーウォーカー",
+  },
+  johnniewalkerblue: {
+    en: "Johnnie Walker Blue Label",
+    ko: "조니 워커 블루 라벨",
+    ja: "ジョニーウォーカー ブルーラベル",
+  },
+  johnniewalkergreen: {
+    en: "Johnnie Walker Green Label",
+    ko: "조니 워커 그린 라벨",
+    ja: "ジョニーウォーカー グリーンラベル",
+  },
+  johnniewalkerblack: {
+    en: "Johnnie Walker Black Label",
+    ko: "조니 워커 블랙 라벨",
+    ja: "ジョニーウォーカー ブラックラベル",
+  },
+  johnniewalkerred: {
+    en: "Johnnie Walker Red Label",
+    ko: "조니 워커 레드 라벨",
+    ja: "ジョニーウォーカー レッドラベル",
+  },
+  johnniewalkerplatinum: {
+    en: "Johnnie Walker Platinum Label",
+    ko: "조니 워커 플래티넘 라벨",
+    ja: "ジョニーウォーカー プラチナラベル",
+  },
+  johnniewalkerxr21: {
+    en: "Johnnie Walker XR 21",
+    ko: "조니 워커 XR 21",
+    ja: "ジョニーウォーカー XR 21",
+  },
+  chivas12: {
+    en: "Chivas Regal 12",
+    ko: "시바스 리갈 12년",
+    ja: "シーバスリーガル12年",
+  },
+  chivas18: {
+    en: "Chivas Regal 18",
+    ko: "시바스 리갈 18년",
+    ja: "シーバスリーガル18年",
+  },
+  chivas25: {
+    en: "Chivas Regal 25",
+    ko: "시바스 리갈 25년",
+    ja: "シーバスリーガル25年",
+  },
+  chivasmizunara: {
+    en: "Chivas Regal Mizunara",
+    ko: "시바스 리갈 미즈나라",
+    ja: "シーバスリーガル ミズナラ",
+  },
+  ballantines: {
+    en: "Ballantine's",
+    ko: "발렌타인",
+    ja: "バランタイン",
+  },
+  ballantinesfinest: {
+    en: "Ballantine's Finest",
+    ko: "발렌타인 파이니스트",
+    ja: "バランタイン ファイネスト",
+  },
+  ballantines17: {
+    en: "Ballantine's 17",
+    ko: "발렌타인 17년",
+    ja: "バランタイン17年",
+  },
+  ballantines21: {
+    en: "Ballantine's 21",
+    ko: "발렌타인 21년",
+    ja: "バランタイン21年",
+  },
+  ballantines30: {
+    en: "Ballantine's 30",
+    ko: "발렌타인 30년",
+    ja: "バランタイン30年",
+  },
+  dewars: {
+    en: "Dewar's",
+    ko: "듀어스",
+    ja: "デュワーズ",
+  },
+  dewarswhitelabel: {
+    en: "Dewar's White Label",
+    ko: "듀어스 화이트 라벨",
+    ja: "デュワーズ ホワイトラベル",
+  },
+  dewars12: {
+    en: "Dewar's 12",
+    ko: "듀어스 12년",
+    ja: "デュワーズ12年",
+  },
+  dewars15: {
+    en: "Dewar's 15",
+    ko: "듀어스 15년",
+    ja: "デュワーズ15年",
+  },
+  dewars18: {
+    en: "Dewar's 18",
+    ko: "듀어스 18년",
+    ja: "デュワーズ18年",
+  },
+
+  // 재팬 위스키 추가
+  suntoryao: {
+    en: "Suntory Ao",
+    ko: "산토리 아오",
+    ja: "サントリー碧",
+  },
+  suntorypremiumblend: {
+    en: "Suntory Premium Blended",
+    ko: "산토리 프리미엄 블렌디드",
+    ja: "サントリープレミアムブレンデッド",
+  },
+  yamazaki12: {
+    en: "Yamazaki 12",
+    ko: "야마자키 12년",
+    ja: "山崎12年",
+  },
+  yamazaki18: {
+    en: "Yamazaki 18",
+    ko: "야마자키 18년",
+    ja: "山崎18年",
+  },
+  yamazaki25: {
+    en: "Yamazaki 25",
+    ko: "야마자키 25년",
+    ja: "山崎25年",
+  },
+  hakushu12: {
+    en: "Hakushu 12",
+    ko: "하쿠슈 12년",
+    ja: "白州12年",
+  },
+  hakushu18: {
+    en: "Hakushu 18",
+    ko: "하쿠슈 18년",
+    ja: "白州18年",
+  },
+  hakushu25: {
+    en: "Hakushu 25",
+    ko: "하쿠슈 25년",
+    ja: "白州25年",
+  },
+  hibiki17: {
+    en: "Hibiki 17",
+    ko: "히비키 17년",
+    ja: "響17年",
+  },
+  hibiki21: {
+    en: "Hibiki 21",
+    ko: "히비키 21년",
+    ja: "響21年",
+  },
+  hibiki30: {
+    en: "Hibiki 30",
+    ko: "히비키 30년",
+    ja: "響30年",
+  },
+  nikkataketsuru: {
+    en: "Nikka Taketsuru",
+    ko: "니카 다케츠루",
+    ja: "ニッカ竹鶴",
+  },
+  nikkataketsuru17: {
+    en: "Nikka Taketsuru 17",
+    ko: "니카 다케츠루 17년",
+    ja: "ニッカ竹鶴17年",
+  },
+  nikkataketsuru21: {
+    en: "Nikka Taketsuru 21",
+    ko: "니카 다케츠루 21년",
+    ja: "ニッカ竹鶴21年",
+  },
+  nikkataketsuru25: {
+    en: "Nikka Taketsuru 25",
+    ko: "니카 다케츠루 25년",
+    ja: "ニッカ竹鶴25年",
+  },
+  nikkafromthebarrel: {
+    en: "Nikka From The Barrel",
+    ko: "니카 프롬 더 배럴",
+    ja: "ニッカフロムザバレル",
+  },
+  nikkacoffee: {
+    en: "Nikka Coffey Grain",
+    ko: "니카 커피 그레인",
+    ja: "ニッカカフェグレーン",
+  },
+  nikkacoffeymalt: {
+    en: "Nikka Coffey Malt",
+    ko: "니카 커피 몰트",
+    ja: "ニッカカフェモルト",
+  },
+  yoichisingle: {
+    en: "Yoichi Single Malt",
+    ko: "요이치 싱글 몰트",
+    ja: "余市シングルモルト",
+  },
+  miyagikyosingle: {
+    en: "Miyagikyo Single Malt",
+    ko: "미야기쿄 싱글 몰트",
+    ja: "宮城峡シングルモルト",
+  },
+
+  matsuikurayoshi: {
+    en: "Matsui Kurayoshi",
+    ko: "마츠이 쿠라요시",
+    ja: "マツイ クラヨシ",
+  },
+  matsuishuzo: {
+    en: "Matsui Shuzo",
+    ko: "마츠이 슈조",
+    ja: "マツイ酒造",
+  },
+  karuizawa: {
+    en: "Karuizawa",
+    ko: "카루이자와",
+    ja: "軽井沢",
+  },
+  karuizawa1960: {
+    en: "Karuizawa 1960",
+    ko: "카루이자와 1960",
+    ja: "軽井沢1960",
+  },
+  karuizawa1970: {
+    en: "Karuizawa 1970",
+    ko: "카루이자와 1970",
+    ja: "軽井沢1970",
+  },
+
+  // 타이완 위스키
+  kavalanconcertmaster: {
+    en: "Kavalan Concertmaster",
+    ko: "카발란 콘서트마스터",
+    ja: "カバラン コンサートマスター",
+  },
+  kavalanconductor: {
+    en: "Kavalan Conductor",
+    ko: "카발란 컨덕터",
+    ja: "カバラン コンダクター",
+  },
+  kavalansolo: {
+    en: "Kavalan Solist",
+    ko: "카발란 솔리스트",
+    ja: "カバラン ソリスト",
+  },
+  kavalankingcar: {
+    en: "Kavalan King Car",
+    ko: "카발란 킹카",
+    ja: "カバラン キングカー",
+  },
+  kavalandomark: {
+    en: "Kavalan Omar",
+    ko: "카발란 오마르",
+    ja: "カバラン オマー",
+  },
+
+  // 스페이사이드 추가
+  glenfarclas10: {
+    en: "Glenfarclas 10",
+    ko: "글렌파클라스 10년",
+    ja: "グレンファークラス10年",
+  },
+  glenfarclas12: {
+    en: "Glenfarclas 12",
+    ko: "글렌파클라스 12년",
+    ja: "グレンファークラス12年",
+  },
+  glenfarclas15: {
+    en: "Glenfarclas 15",
+    ko: "글렌파클라스 15년",
+    ja: "グレンファークラス15年",
+  },
+  glenfarclas17: {
+    en: "Glenfarclas 17",
+    ko: "글렌파클라스 17년",
+    ja: "グレンファークラス17年",
+  },
+  glenfarclas21: {
+    en: "Glenfarclas 21",
+    ko: "글렌파클라스 21년",
+    ja: "グレンファークラス21年",
+  },
+  glenfarclas25: {
+    en: "Glenfarclas 25",
+    ko: "글렌파클라스 25년",
+    ja: "グレンファークラス25年",
+  },
+  glenfarclas30: {
+    en: "Glenfarclas 30",
+    ko: "글렌파클라스 30년",
+    ja: "グレンファークラス30年",
+  },
+  glenfarclas40: {
+    en: "Glenfarclas 40",
+    ko: "글렌파클라스 40년",
+    ja: "グレンファークラス40年",
+  },
+
+  // 하이랜드 추가
+  glenmorangie10: {
+    en: "Glenmorangie 10",
+    ko: "글렌모렌지 10년",
+    ja: "グレンモーレンジ10年",
+  },
+  glenmorangie12: {
+    en: "Glenmorangie 12 Lasanta",
+    ko: "글렌모렌지 12년 라산타",
+    ja: "グレンモーレンジ12年 ラサンタ",
+  },
+  glenmorangie14: {
+    en: "Glenmorangie 14 Quinta Ruban",
+    ko: "글렌모렌지 14년 퀸타 루반",
+    ja: "グレンモーレンジ14年 キンタルバン",
+  },
+  glenmorangie18: {
+    en: "Glenmorangie 18",
+    ko: "글렌모렌지 18년",
+    ja: "グレンモーレンジ18年",
+  },
+
+  // 아일라 추가
+  ardbeg10: {
+    en: "Ardbeg 10",
+    ko: "아드벡 10년",
+    ja: "アードベッグ10年",
+  },
+  ardbegoogy: {
+    en: "Ardbeg Oogie",
+    ko: "아드벡 우기",
+    ja: "アードベッグ ウーギー",
+  },
+  ardbegcorry: {
+    en: "Ardbeg Corryvreckan",
+    ko: "아드벡 코리브레칸",
+    ja: "アードベッグ コリーヴレッカン",
+  },
+  bowmore12: {
+    en: "Bowmore 12",
+    ko: "보모어 12년",
+    ja: "ボウモア12年",
+  },
+  bowmore15: {
+    en: "Bowmore 15",
+    ko: "보모어 15년",
+    ja: "ボウモア15年",
+  },
 } as const;

--- a/src/utils/translateWhiskyNameToJapenese.ts
+++ b/src/utils/translateWhiskyNameToJapenese.ts
@@ -1,4 +1,36 @@
 import { whiskyDictionary } from "@/constants/whiskyDictionary";
+// Levenshtein 거리 계산 함수 추가
+function levenshteinDistance(a: string, b: string): number {
+  const matrix = Array(b.length + 1)
+    .fill(null)
+    .map(() => Array(a.length + 1).fill(null));
+
+  for (let i = 0; i <= a.length; i++) matrix[0][i] = i;
+  for (let j = 0; j <= b.length; j++) matrix[j][0] = j;
+
+  for (let j = 1; j <= b.length; j++) {
+    for (let i = 1; i <= a.length; i++) {
+      const indicator = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[j][i] = Math.min(
+        matrix[j][i - 1] + 1,
+        matrix[j - 1][i] + 1,
+        matrix[j - 1][i - 1] + indicator
+      );
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+// 문자열 정규화 함수
+function normalizeString(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\s+/g, "") // 모든 공백 제거
+    .replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "") // 특수문자 제거
+    .replace(/(whisky|whiskey|위스키)/gi, "") // 위스키 관련 일반 단어 제거
+    .replace(/(single|malt|싱글|몰트)/gi, ""); // 일반적인 위스키 용어 제거
+}
+
 // 검색어 전처리 함수
 export function cleanWhiskyName(input: string): string {
   return input
@@ -30,42 +62,53 @@ export function extractYearInfo(input: string): string {
 
   return "";
 }
-// 검색 함수
+
+// 검색 함수 수정
 export function translateWhiskyNameToJapenese(input: string): {
   found: boolean;
   japanese?: string;
   yearInfo?: string;
 } {
   const yearInfo = extractYearInfo(input);
-  const cleaned = cleanWhiskyName(input);
+  const normalizedInput = normalizeString(input);
 
-  // 1. 정확한 매칭 시도
+  // 유사도 결과를 저장할 배열
+  const matches: {
+    key: string;
+    similarity: number;
+    value: (typeof whiskyDictionary)[keyof typeof whiskyDictionary];
+  }[] = [];
+
+  // 모든 위스키 항목에 대해 유사도 검사
   for (const [key, value] of Object.entries(whiskyDictionary)) {
-    if (
-      cleaned.includes(key) ||
-      cleaned.includes(value.ko) ||
-      cleaned.includes(value.en.toLowerCase())
-    ) {
-      return {
-        found: true,
-        japanese: yearInfo ? `${value.ja} ${yearInfo}` : value.ja,
-        yearInfo,
-      };
-    }
+    const normalizedKo = normalizeString(value.ko);
+    const normalizedEn = normalizeString(value.en);
+
+    // 한국어와 영어 이름 모두에 대해 유사도 계산
+    const koDistance = levenshteinDistance(normalizedInput, normalizedKo);
+    const enDistance = levenshteinDistance(normalizedInput, normalizedEn);
+
+    // 더 작은 거리 값 사용 (더 유사한 것)
+    const minDistance = Math.min(koDistance, enDistance);
+
+    // 유사도 점수 계산 (거리가 짧을수록 유사도가 높음)
+    const similarity = 1 / (minDistance + 1);
+
+    matches.push({ key, similarity, value });
   }
 
-  // 3. 부분 매칭 시도
-  for (const [key, value] of Object.entries(whiskyDictionary)) {
-    if (
-      value.ko.includes(cleaned) ||
-      value.en.toLowerCase().includes(cleaned)
-    ) {
-      return {
-        found: true,
-        japanese: yearInfo ? `${value.ja} ${yearInfo}` : value.ja,
-        yearInfo,
-      };
-    }
+  // 유사도가 가장 높은 항목 찾기
+  matches.sort((a, b) => b.similarity - a.similarity);
+
+  // 유사도가 일정 수준 이상인 경우에만 결과 반환
+  if (matches.length > 0 && matches[0].similarity > 0.1) {
+    // 임계값 조정 가능
+    const bestMatch = matches[0].value;
+    return {
+      found: true,
+      japanese: yearInfo ? `${bestMatch.ja} ${yearInfo}` : bestMatch.ja,
+      yearInfo,
+    };
   }
 
   return { found: false };


### PR DESCRIPTION
## 🚀 Jira 티켓

**[BYOB-227]**

<br>

## 🔨 작업 사항
- Levenshtein거리를 통한 무카와 일본어 검색 기능 보완
- 일본어 위스키 사전 추가

[BYOB-227]: https://swm-alcoholic.atlassian.net/browse/BYOB-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
